### PR TITLE
intake: upstream #1344 (intake/lote-B-pr-1344)

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,6 +1,7 @@
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
 **Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -1,8 +1,11 @@
 # Feature Specification: [FEATURE NAME]
 
-**Feature Branch**: `[###-feature-name]`  
-**Created**: [DATE]  
-**Status**: Draft  
+**Feature Branch**: `[###-feature-name]`
+
+**Created**: [DATE]
+
+**Status**: Draft
+
 **Input**: User description: "$ARGUMENTS"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -6,6 +6,7 @@ description: "Task list template for feature implementation"
 # Tasks: [FEATURE NAME]
 
 **Input**: Design documents from `/specs/[###-feature-name]/`
+
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.


### PR DESCRIPTION
## Intake PR (Review Phase)
- Source upstream PR: https://github.com/github/spec-kit/pull/1344
- Source title: fix: Use blank lines in template headers to prevent markdownlint stripping line breaks
- Intake branch:       `intake/lote-B-pr-1344`
- Base baseline: `baseline/main-sync-2026-02-17`

## Policy
- This PR is for review and validation only.
- Do **not** merge until Gemini/Copilot review + local validation are complete.
- We will follow the 7-step integration workflow.