### PR TITLE
fix: move risk mitigation from SELECT to STRUCTURE/VALIDATE phases (#31)

### DIFF
--- a/templates/commands/select.md
+++ b/templates/commands/select.md
@@ -55,3 +55,4 @@ AI-RICE extends RICE by adding Data_Readiness and Risk.
 - Score formula applied consistently
 - Winner + runner-ups documented
 - Validator passes
+- **Note**: Risk mitigations are NOT defined here; they belong in STRUCTURE (canvas component 16) and are validated in VALIDATE (G0 criterion Q5).

--- a/templates/idea-selection-template.md
+++ b/templates/idea-selection-template.md
@@ -69,8 +69,12 @@ Guidance:
 - Score: [value]
 - Why it is a strong alternative
 
-## Risk Mitigation (Selected Idea)
+## Risk Note
 
-| Risk | Mitigation | Owner | Notes |
-| ------ | ------------ | ------- | ------- |
-| [Risk] | [Mitigation] | [Owner] | [Notes] |
+> **Risk mitigations are defined in the STRUCTURE phase**, not here.
+>
+> The **Risk** dimension above (1–10 scale) feeds the AI-RICE score to inform selection.
+> Concrete mitigations, owners, and controls are documented in:
+>
+> - `ai_vision_canvas.md` → Component 16: Safety & Risk (created in STRUCTURE)
+> - `approvals/g0-validation-report.md` → Criterion Q5: Risk mitigations defined (validated in VALIDATE)


### PR DESCRIPTION
## Summary

Closes #31

The `idea-selection-template.md` had a 'Risk Mitigation' table that asked for concrete mitigations during the **SELECT phase**. This is premature — at SELECT time, we only have a Risk score (1-10) to weight the AI-RICE formula.

## Root Cause

Template design error: mitigations require knowledge of the selected idea's full context, which is only available after STRUCTURE (canvas) and is formally validated in VALIDATE (G0 criterion Q5).

## Changes

### `templates/idea-selection-template.md`
- Removed premature Risk Mitigation table
- Added guidance note pointing to:
  - `ai_vision_canvas.md` → Component 16: Safety & Risk (STRUCTURE phase)
  - `approvals/g0-validation-report.md` → Criterion Q5 (VALIDATE phase)

### `templates/commands/select.md`
- Added clarifying note to Completion Criteria: mitigations belong to STRUCTURE/VALIDATE

## Phase Correctness (Before → After)

| Phase | Before | After |
|-------|--------|-------|
| SELECT | Risk score + mitigation table (❌ premature) | Risk score only (✅) |
| STRUCTURE | Canvas component 16 (mitigations) | Canvas component 16 (mitigations) (✅) |
| VALIDATE | G0 Q5: risk mitigations defined | G0 Q5: risk mitigations defined (✅) |

## Testing

- 228/228 tests pass
- markdownlint: 0 errors