### PR TITLE
feat: add backlinks from selection report to source ideas (#28)

### DIFF
--- a/templates/commands/select.md
+++ b/templates/commands/select.md
@@ -24,6 +24,11 @@ agent_scripts:
 4. Calculate AI-RICE score: (Reach * Impact * Confidence * Data_Readiness) / (Effort * Risk).
 5. Identify top-scoring idea; include runner-ups.
 6. Write .spec-kit/idea_selection.md using idea-selection-template.md.
+   - For every Idea ID in the table and in Selected/Runner-Up sections, generate a markdown
+     link to the corresponding heading anchor in ideas_backlog.md.
+   - Anchor derivation: lowercase the heading text after "### Idea ", replace spaces with
+     hyphens. Examples: "Idea S1" → #idea-s1; "Idea SC1-Substitute" → #idea-sc1-substitute.
+   - Link format: [IDEA_ID](.spec-kit/ideas_backlog.md#idea-<anchor>)
 7. Validate AI-RICE completeness with validate-airice.{sh|ps}.
 8. Update state: set current_phase=structure; record idea_selection path.
 9. Report completion and selected idea.

--- a/templates/idea-selection-template.md
+++ b/templates/idea-selection-template.md
@@ -13,6 +13,7 @@ enables: .spec-kit/ai_vision_canvas.md
 
 **Generated**: [ISO_8601_TIMESTAMP]
 **Ideas Evaluated**: [COUNT]
+**Source Backlog**: [ideas_backlog.md](.spec-kit/ideas_backlog.md)
 
 <!--
 Guidance:
@@ -25,21 +26,23 @@ Guidance:
 - Effort is person-weeks.
 - Risk is 1-10 (higher = riskier).
 - Data_Readiness is 0-100%.
+- Idea IDs in the table MUST link to the corresponding heading anchor in ideas_backlog.md.
+  Anchor format: lowercase, spaces→hyphens, e.g. "Idea S1" → #idea-s1
 -->
 
 ## AI-RICE Scoring Table
 
 | Idea ID | Reach | Impact | Confidence | Data_Readiness | Effort | Risk | AI-RICE Score |
 | --------- | ------- | -------- | ------------ | ---------------- | -------- | ------ | --------------- |
-| S1 | 1000 | 2.0 | 70% | 80% | 4 | 3 | 93.3 |
-| SC1-Substitute | 1500 | 1.5 | 60% | 50% | 6 | 5 | 37.5 |
+| [S1](.spec-kit/ideas_backlog.md#idea-s1) | 1000 | 2.0 | 70% | 80% | 4 | 3 | 93.3 |
+| [SC1-Substitute](.spec-kit/ideas_backlog.md#idea-sc1-substitute) | 1500 | 1.5 | 60% | 50% | 6 | 5 | 37.5 |
 | ... | ... | ... | ... | ... | ... | ... | ... |
 
 **Formula**: (Reach \* Impact \* Confidence \* Data_Readiness) / (Effort \* Risk)
 
 ## Selected Idea
 
-**ID**: [IDEA_ID]
+**ID**: [[IDEA_ID]](.spec-kit/ideas_backlog.md#idea-[IDEA_ID_ANCHOR])
 **Text**: [Idea description]
 **Tag**: [SEED | SCAMPER-<Lens> | HMW-<Dimension>]
 **AI-RICE Score**: [Score]
@@ -59,12 +62,12 @@ Guidance:
 
 ## Runner-Ups (Pivot Options)
 
-### 2nd Place: [IDEA_ID]
+### 2nd Place: [[IDEA_ID]](.spec-kit/ideas_backlog.md#idea-[IDEA_ID_ANCHOR])
 
 - Score: [value]
 - Why it is a strong alternative
 
-### 3rd Place: [IDEA_ID]
+### 3rd Place: [[IDEA_ID]](.spec-kit/ideas_backlog.md#idea-[IDEA_ID_ANCHOR])
 
 - Score: [value]
 - Why it is a strong alternative


### PR DESCRIPTION
## Summary

Closes #28

The `idea_selection.md` had no links back to the source ideas in `ideas_backlog.md`, breaking traceability. Users had to manually cross-reference Idea IDs.

## Changes

### `templates/idea-selection-template.md`
- Added **Source Backlog** link in the report header
- All Idea IDs in the AI-RICE scoring table are now markdown links to the corresponding heading anchor in `ideas_backlog.md`
- Selected Idea ID and Runner-Up IDs also linked
- Added anchor derivation rule in template comment

### `templates/commands/select.md`
- Extended EXECUTION_FLOW step 6 with explicit link generation instructions
- Anchor derivation rule documented: lowercase heading text after '### Idea ', spaces → hyphens
  - e.g. 'Idea S1' → `#idea-s1`; 'Idea SC1-Substitute' → `#idea-sc1-substitute`

## Before / After

**Before**: `| S1 | 1000 | 2.0 | ... |`

**After**: `| [S1](.spec-kit/ideas_backlog.md#idea-s1) | 1000 | 2.0 | ... |`

## Testing
- 228/228 tests pass
- markdownlint: 0 errors