### PR TITLE
fix(clarify): correct question limit from 10 to 5

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -91,7 +91,7 @@ Execution steps:
    - Information is better deferred to planning phase (note internally)
 
 3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
-    - Maximum of 10 total questions across the whole session.
+    - Maximum of 5 total questions across the whole session.
     - Each question must be answerable with EITHER:
        - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
        - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").


### PR DESCRIPTION
## Summary

Fixes an internal inconsistency in the `clarify` command template introduced when it was first written:

- Line 91 says: *"prioritized queue of candidate clarification questions (maximum 5)"*
- Line 92 said: *"Maximum of **10** total questions across the whole session"* ← **BUG**

Both should say **5**. Upstream caught this in [github/spec-kit#1557](https://github.com/github/spec-kit/pull/1557).

## Change

```diff
-    - Maximum of 10 total questions across the whole session.
+    - Maximum of 5 total questions across the whole session.
```

**1 line changed in 1 file.** No code changes.

## Testing

- ✅ `npx markdownlint-cli2 templates/commands/clarify.md` — 0 errors
- ✅ `uv run pytest tests/ -x -q` — 317 passed, 22 skipped

## Notes

The Gemini review on intake PR #59 noted the `(maximum 5)` on line 91 becomes redundant with this fix and could be removed in a future cleanup. Kept out of scope here to keep this change minimal.

Closes #59