### PR TITLE
docs(templates): update plan-template.md path reference to be agent-agnostic

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -3,7 +3,7 @@
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+**Note**: This template is filled in by the `/speckit.plan` command. The execution workflow is defined in your AI agent's command configuration (e.g., `.claude/commands/speckit.plan.md`, `.cursor/commands/speckit.plan.md`, `.codex/prompts/speckit.plan.md`, etc.).
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Intake of upstream PR [#1342](https://github.com/github/spec-kit/pull/1342) (cherry-picked with `git cherry-pick -x`).

**Author**: venkatp-infomagnus

## Changes

Replace hardcoded `.specify/templates/commands/plan.md` path in `plan-template.md` with an agent-agnostic reference pointing to each AI agent's command configuration directory (e.g., `.claude/commands/`, `.cursor/commands/`, `.codex/prompts/`, etc.).

This path didn't exist for most AI agents and caused confusion.

## Verification

- `git cherry-pick -x 3a58916` — authorship preserved ✅
- `317 passed, 22 skipped` — no regressions ✅
- `markdownlint-cli2` — 0 errors ✅

Closes #56