### PR TITLE
fix(templates): add blank lines between template header fields for consistent rendering

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,6 +1,7 @@
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
 **Note**: This template is filled in by the `/speckit.plan` command. The execution workflow is defined in your AI agent's command configuration (e.g., `.claude/commands/speckit.plan.md`, `.cursor/commands/speckit.plan.md`, `.codex/prompts/speckit.plan.md`, etc.).

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -9,9 +9,12 @@ enables: null
 
 # Feature Specification: [FEATURE NAME]
 
-**Feature Branch**: `[###-feature-name]`  
-**Created**: [DATE]  
-**Status**: Draft  
+**Feature Branch**: `[###-feature-name]`
+
+**Created**: [DATE]
+
+**Status**: Draft
+
 **Input**: User description: "$ARGUMENTS"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -6,6 +6,7 @@ description: "Task list template for feature implementation"
 # Tasks: [FEATURE NAME]
 
 **Input**: Design documents from `/specs/[###-feature-name]/`
+
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.


### PR DESCRIPTION
## Summary

Intake of upstream PR [#1344](https://github.com/github/spec-kit/pull/1344) (cherry-picked with `git cherry-pick -x`).

**Author**: Ed Harrod

## Changes

Template headers used trailing double-spaces for line breaks, which don't render correctly in GitHub or JetBrains IDEs. Replaced with blank lines for consistent cross-platform rendering across:
- `templates/plan-template.md`
- `templates/spec-template.md`
- `templates/tasks-template.md`

## Verification

- `git cherry-pick -x 61d2930` — authorship preserved ✅
- `317 passed, 22 skipped` — no regressions ✅
- `markdownlint-cli2` — 0 errors on all 11 templates ✅

Closes #63