### PR TITLE
docs(process): fix intake preflight, lane consistency, and lint guidance

### DIFF
--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -28,6 +28,37 @@ This fork tracks the upstream repository (`github/spec-kit`) while keeping fork-
 
 5. Push your fork branch back to `origin`.
 
+## Selective Intake Preflight (Mandatory)
+
+Before starting any upstream intake batch, run:
+
+```bash
+git fetch origin upstream --prune
+git rev-parse --short origin/main
+gh pr list -R nsalvacao/spec-kit --state open --json number,title,headRefName,baseRefName,url
+```
+
+Treat these live values as source of truth. Do not rely on stale handoff snapshots for SHAs, branch state, or PR counts.
+
+## Single-Lane Intake Policy
+
+For selective upstream PR intake, use one lane consistently across the full batch:
+
+- Intake branches: `intake/lote-<A|B|C>-pr-<upstream_pr_number>`
+- Review PR target: `baseline/main-sync-YYYY-MM-DD`
+- Promotion PR target (after batch): `main`
+
+Do not mix intake flow (`intake -> baseline`) with feature flow (`feat -> main`) in the same intake batch unless explicitly requested by repository owner.
+
+## Intake Validation Commands
+
+```bash
+uv run pytest tests/ --tb=short
+git ls-files -z '*.md' ':!:extensions/**' | xargs -0 npx markdownlint-cli2
+```
+
+The markdown command above avoids local untracked/archive noise and aligns with CI-relevant tracked files.
+
 ## Keeping Fork Changes Isolated
 
 - Prefer additive changes in `templates/`, `scripts/`, and documented overrides


### PR DESCRIPTION
## Why
This resolves three workflow inconsistencies identified during Lote C intake:
1. stale handoff snapshots being used as operational truth
2. mixed lane guidance (`feat/* -> main` vs `intake/* -> baseline/*`)
3. markdown lint command too broad for local repos with untracked/archive files

## What Changed
- `.github/copilot-instructions.md`
  - Added mandatory intake preflight commands
  - Enforced single-lane intake policy (baseline lane)
  - Replaced broad markdown lint command with tracked-file, CI-aligned lint command
- `docs/upstream-sync.md`
  - Added selective intake preflight section
  - Documented single-lane policy for intake batches
  - Added intake validation commands (`pytest` + tracked markdown lint)

## Validation
- `npx markdownlint-cli2 .github/copilot-instructions.md docs/upstream-sync.md` -> `0 errors`
