### PR TITLE
intake: upstream value (CLI option parsing robustness)

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1390,7 +1390,7 @@ def init(
         show_banner()
 
     # Guard against option flags being consumed as values for --ai.
-    if ai_assistant and ai_assistant.startswith("--"):
+    if ai_assistant and ai_assistant.startswith("-"):
         console.print(f"[red]Error:[/red] Invalid value for --ai: '{ai_assistant}'")
         console.print("[yellow]Hint:[/yellow] Did you forget to provide a value for --ai?")
         console.print("[yellow]Example:[/yellow] specify init --ai claude --here")

--- a/tests/test_cli_parameter_ordering.py
+++ b/tests/test_cli_parameter_ordering.py
@@ -26,3 +26,12 @@ def test_ai_flag_missing_value_lists_available_agents():
     assert "Available agents:" in result.output
     assert "claude" in result.output
     assert "copilot" in result.output
+
+
+def test_ai_flag_short_option_like_value_reports_helpful_error():
+    """`--ai -x` should also be treated as an invalid value for --ai."""
+    result = runner.invoke(app, ["init", "--ai", "-x", "--no-banner"])
+
+    assert result.exit_code == 1
+    assert "Invalid value for --ai" in result.output
+    assert "-x" in result.output


### PR DESCRIPTION
## Summary
Applies a scoped robustness fix inspired by upstream parameter-ordering improvements: detect when an option flag is accidentally consumed as the value for `--ai`.

## Upstream Provenance
- Partial adaptation from `3040d33` (parameter ordering issues in CLI)

## Scope Kept Intentionally Narrow
- Added early guard in `init()` for invalid `--ai` values like `--here`.
- Added focused tests in `tests/test_cli_parameter_ordering.py`.
- Did **not** import unrelated upstream changes (version/CODEOWNERS/changelog/test file layout differences).

## Validation
- `uv run pytest tests/test_cli_parameter_ordering.py --tb=short -q`
- `uv run pytest tests/test_multi_agent_init.py::TestMultiAgentParsing::test_single_agent_still_works --tb=short -q`

## Credit
Commit message includes explicit upstream provenance and co-authorship.
