### PR TITLE
ci(sync): auto-update baseline PRs when behind main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -269,6 +269,7 @@ When choosing what to work on, apply this order:
 | `ai-review.yml` | ✅ Active | PR — GitHub Models code review (long-context + fallback chain) |
 | `test.yml` | ✅ Active | Push/PR — `uv run pytest` |
 | `release.yml` | ✅ Active | Push to `main` — semantic versioning (latest tag from repo releases) |
+| `baseline-auto-sync.yml` | ✅ Active | Push to `main` + baseline PR events — auto-sync `baseline/* -> main` branches |
 
 ### Known CI Status
 
@@ -278,6 +279,8 @@ Current baseline (latest published release tag):
 - `ai-triage.yml` was intentionally removed (obsolete/unused).
 - `ai-review.yml` now validates token presence, checks tenant model catalog availability, supports configurable A/B model pools, and appends timeline logs to workflow summaries.
 - `ai-review.yml` defaults are designed for large diffs (chunking enabled; no global diff truncation in normal path).
+- `baseline-auto-sync.yml` automatically triggers "Update branch" for open `baseline/* -> main`
+  PRs when `main` advances, reducing manual merge drift during parallel lanes.
 
 ### AI Review Runtime Configuration (Repository Variables)
 

--- a/.github/workflows/baseline-auto-sync.yml
+++ b/.github/workflows/baseline-auto-sync.yml
@@ -1,0 +1,130 @@
+name: Baseline Auto Sync
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to sync (must be baseline/* -> main)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: baseline-auto-sync
+  cancel-in-progress: false
+
+jobs:
+  baseline-auto-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and sync baseline PRs behind main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          summary() {
+            echo "$1" >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          collect_open_baseline_prs() {
+            gh pr list \
+              --repo "$REPO" \
+              --state open \
+              --base main \
+              --json number,headRefName \
+              --jq '.[] | select(.headRefName | startswith("baseline/")) | .number'
+          }
+
+          sync_pr_if_behind() {
+            local pr_number="$1"
+            local pr_json head_ref base_ref head_sha pr_url compare_json
+            local behind_by ahead_by compare_status update_output update_exit
+
+            pr_json="$(gh api "repos/${REPO}/pulls/${pr_number}")"
+            head_ref="$(jq -r '.head.ref' <<< "$pr_json")"
+            base_ref="$(jq -r '.base.ref' <<< "$pr_json")"
+            head_sha="$(jq -r '.head.sha' <<< "$pr_json")"
+            pr_url="$(jq -r '.html_url' <<< "$pr_json")"
+
+            if [[ "$base_ref" != "main" || "$head_ref" != baseline/* ]]; then
+              summary "- Skip PR #${pr_number}: not a \`baseline/* -> main\` PR (${head_ref} -> ${base_ref})."
+              return 0
+            fi
+
+            compare_json="$(gh api "repos/${REPO}/compare/${base_ref}...${head_ref}")"
+            behind_by="$(jq -r '.behind_by' <<< "$compare_json")"
+            ahead_by="$(jq -r '.ahead_by' <<< "$compare_json")"
+            compare_status="$(jq -r '.status' <<< "$compare_json")"
+
+            summary "- PR #${pr_number} (${pr_url}): status=\`${compare_status}\`, behind=${behind_by}, ahead=${ahead_by}."
+
+            if [[ "$behind_by" == "0" ]]; then
+              summary "  - No sync needed."
+              return 0
+            fi
+
+            set +e
+            update_output="$(gh api -X PUT "repos/${REPO}/pulls/${pr_number}/update-branch" -f expected_head_sha="${head_sha}" 2>&1)"
+            update_exit=$?
+            set -e
+
+            if [[ "$update_exit" -ne 0 ]]; then
+              summary "  - Sync attempt failed (non-blocking)."
+              summary "  - \`$update_output\`"
+              return 0
+            fi
+
+            summary "  - Sync triggered successfully via Update Branch API."
+            return 0
+          }
+
+          summary "## Baseline Auto Sync"
+          summary ""
+          summary "- Trigger: \`${EVENT_NAME}\`"
+          summary ""
+
+          mapfile -t targets < <(
+            if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+              if [[ -n "$EVENT_PR_NUMBER" ]]; then
+                echo "$EVENT_PR_NUMBER"
+              fi
+            elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+              if [[ -n "$INPUT_PR_NUMBER" ]]; then
+                echo "$INPUT_PR_NUMBER"
+              else
+                collect_open_baseline_prs
+              fi
+            else
+              collect_open_baseline_prs
+            fi
+          )
+
+          if [[ "${#targets[@]}" -eq 0 ]]; then
+            summary "- No open \`baseline/* -> main\` PRs found."
+            exit 0
+          fi
+
+          declare -A seen=()
+          for pr in "${targets[@]}"; do
+            if [[ -n "${seen[$pr]+x}" ]]; then
+              continue
+            fi
+            seen["$pr"]=1
+            sync_pr_if_behind "$pr"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release metadata sync automation**
   - Updated `.github/workflows/release-metadata-sync.yml` to use `version-orchestrator.py sync`.
   - Metadata sync now propagates to `uv.lock` in addition to `pyproject.toml` and `CHANGELOG.md`.
+- **Baseline promotion sync automation**
+  - Added `.github/workflows/baseline-auto-sync.yml` to detect open `baseline/* -> main`
+    PRs and auto-trigger GitHub's "Update branch" when `main` moves ahead.
+  - Added manual entry point (`workflow_dispatch`) with optional PR number targeting.
+  - Added release-process and Copilot workflow documentation for the new sync behavior.
 
 ## [0.0.53] - 2026-02-26
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -12,6 +12,7 @@ Release metadata consistency is governed by:
 - Coherence workflow: `.github/workflows/version-coherence.yml`
 - Sync workflow: `.github/workflows/release-metadata-sync.yml`
 - Hygiene workflow: `.github/workflows/branch-hygiene.yml`
+- Baseline sync workflow: `.github/workflows/baseline-auto-sync.yml`
 - Bump helpers:
   - `scripts/bash/version-bump.sh`
   - `scripts/powershell/version-bump.ps1`
@@ -99,6 +100,8 @@ Confirm the tag and assets are published to `nsalvacao/spec-kit`.
 - The sync workflow enforces file safety using `allowlist` from `.github/version-map.yml`.
 - `release-consistency-guard.yml` blocks PRs to `main` when coherence fails.
 - `version-coherence.yml` blocks PRs to `main` when mapped version drift is detected.
+- `baseline-auto-sync.yml` auto-triggers "Update branch" for open `baseline/* -> main`
+  PRs when `main` moves ahead, reducing manual sync drift in parallel work.
 - Nightly monitor mode opens/updates a drift issue when metadata remains inconsistent.
 
 ## 7) Local Main Hygiene


### PR DESCRIPTION
## Summary
- add `baseline-auto-sync.yml` to auto-detect open `baseline/* -> main` PRs that are behind `main`
- auto-trigger GitHub Update Branch API when behind drift is detected
- support `workflow_dispatch` with optional `pr_number` for manual recoveries
- document workflow in release docs and Copilot CI inventory

## Why
Parallel lanes can advance `main` while a baseline promotion PR is still open. This workflow removes manual sync drift by triggering update-branch automatically when needed.

## Triggers
- `push` on `main`
- `pull_request_target` (`opened`, `reopened`, `synchronize`, `ready_for_review`) for PRs targeting `main`
- `workflow_dispatch` (optional PR override)

## Validation
- `npx markdownlint-cli2 CHANGELOG.md docs/release.md .github/copilot-instructions.md`
- YAML parse check for `.github/workflows/baseline-auto-sync.yml` via `python3 + pyyaml`
